### PR TITLE
Prepend effectId in brackets to conform with KoLmafia

### DIFF
--- a/update-data.js
+++ b/update-data.js
@@ -18,9 +18,28 @@ async function getMafiaData(path) {
 
 async function main() {
   const effectLines = await getMafiaData("statuseffects.txt");
-  const effects = effectLines
-    .map((line) => line.split("\t")[1])
-    .filter((name) => name);
+  const parsedEffects = effectLines
+    .map((line) => {
+      const split = line.split("\t");
+      return { id: split[0], name: split[1], edited: false };
+    })
+    .filter((line) => line.name);
+  const effectsReadOnly = { ...parsedEffects };
+  const count = Object.keys(effectsReadOnly).length;
+  for (let i = 0; i < count - 1; ++i) {
+    for (let j = i + 1; j < count; ++j) {
+      if (effectsReadOnly[i].name === effectsReadOnly[j].name) {
+        const disambiguate = (e) => {
+          if (e.edited) return;
+          e.name = `[${e.id}]${e.name}`;
+          e.edited = true;
+        };
+        disambiguate(parsedEffects[i]);
+        disambiguate(parsedEffects[j]);
+      }
+    }
+  }
+  const effects = parsedEffects.map((line) => line.name);
   fs.writeFileSync("data/effects.json", JSON.stringify(effects));
 
   const familiarLines = await getMafiaData("familiars.txt");


### PR DESCRIPTION
KoLmafia disambiguates effects by referring to them as $effect[[id]Effect Name]. This update should change the data to conform with this, that way eslint will warn users when referencing ambiguous effect names in code.

Example:
```
> ash $effect[Slicked-Back Do]

Multiple matches for "Slicked-Back Do"; using "[1553]Slicked-Back Do". () Clarify by using one of:
$effect[[1342]Slicked-Back Do]
$effect[[1553]Slicked-Back Do]
```