### PR TITLE
Suggest a constant if the user writes a substring of one

### DIFF
--- a/lib/rules/verify-constants.ts
+++ b/lib/rules/verify-constants.ts
@@ -150,9 +150,8 @@ const rule: Rule.RuleModule = {
               sourceCode.getIndexFromLoc(end),
             ];
             const segment = segmentRaw.replace(/(?<!\\)\\,/, ",");
-            const properlyCapitalized = tagInfo.caseMap.get(
-              segment.toLowerCase()
-            );
+            const lowerCaseSegment = segment.toLowerCase();
+            const properlyCapitalized = tagInfo.caseMap.get(lowerCaseSegment);
 
             if (properlyCapitalized === undefined) {
               const decoded = decodeEntities(segment);
@@ -173,9 +172,16 @@ const rule: Rule.RuleModule = {
                   });
                 }
               } else if (!options?.ignoreUnrecognized && segment !== "") {
+                let suggestion = "";
+                for (const data of tagInfo.data) {
+                  if (data.toLowerCase().includes(lowerCaseSegment)) {
+                    suggestion = `. Maybe you want "${data}"?`;
+                    break;
+                  }
+                }
                 context.report({
                   node,
-                  message: `Unrecognized enumerated value name "${segment}"`,
+                  message: `Unrecognized enumerated value name "${segment}"${suggestion}`,
                 });
               }
             } else if (


### PR DESCRIPTION
Examples:
```
  488:17  error  Unrecognized enumerated value name "Blood Sugar Sauce Magic". Maybe you want "[1457]Blood Sugar Sauce Magic"?  libram/verify-constants
  490:3   error  Unrecognized enumerated value name "Hip to the Jive". Maybe you want "[1701]Hip to the Jive"?                  libram/verify-constants
```