### PR TITLE
Don't mark template literals as errors

### DIFF
--- a/lib/rules/verify-constants.ts
+++ b/lib/rules/verify-constants.ts
@@ -158,6 +158,8 @@ const rule: Rule.RuleModule = {
       TaggedTemplateExpression(
         node: ESTree.TaggedTemplateExpression & Rule.NodeParentExtension
       ) {
+        // For now just don't check constants if they contain other template literal expressions
+        if (node.quasi.expressions.length > 0) return;
         const tagText = sourceCode.getText(node.tag);
         const singular = singularTags.get(tagText);
         const plural = pluralTags.get(tagText);

--- a/tests/lib/rules/verify-constants.ts
+++ b/tests/lib/rules/verify-constants.ts
@@ -74,6 +74,15 @@ ruleTester.run("verify-constants", rule, {
     {
       code: "$effect``",
     },
+    {
+      code: "$effect`Make Meat FA$T!`",
+    },
+    {
+      code: "$item`Gene Tonic: ${phylum}`",
+    },
+    {
+      code: "$items`Gene Tonic: ${phylum1}, Gene Tonic: ${phylum2}`",
+    },
   ],
 
   invalid: [


### PR DESCRIPTION
This one's a quick fix. The broader solution is much more complex since it involves looking ahead/behind at other quasis if expressions occur between them, and checking for commas in those quasis to separate out other segments.